### PR TITLE
bugfix: 修正secid取值错误

### DIFF
--- a/adata/stock/market/index_market/market_index_east.py
+++ b/adata/stock/market/index_market/market_index_east.py
@@ -103,7 +103,7 @@ class StockMarketIndexEast(StockMarketIndexTemplate):
         :return: [指数代码,交易时间，交易日期，开，高，低，当前价格,成交量，成交额]
         ['trade_time', 'trade_date', 'open', 'high', 'low', 'price', 'volume', 'amount']
         """
-        sec_id = 0 if index_code[0] == 0 else 1
+        sec_id = 1 if index_code[0] == 0 else 0
         url = f"http://push2.eastmoney.com/api/qt/stock/get?" \
               f"invt=2&fltt=1&fields=f58,f107,f57,f43,f59,f169,f170,f152,f46,f60,f44,f45,f47,f48,f19,f532,f39,f161,f49," \
               f"f171,f50,f86,f600,f601,f154,f84,f85,f168,f108,f116,f167,f164,f92,f71,f117,f292,f113,f114,f115,f119," \


### PR DESCRIPTION
stock.market.get_market_index_current() 接口无法获取除上证其他指数的数据

复现方式：
>>> import adata
>>> index_df = adata.stock.market.get_market_index_current(index_code="399001")
>>> print(index_df)
Empty DataFrame
Columns: [index_code, trade_time, trade_date, open, high, low, price, volume, amount]
Index: []

排查发现，并定位是 secid 判断错误：
<img width="961" alt="image" src="https://github.com/user-attachments/assets/d1d15069-310b-4024-92e4-f69afd9d4f04">

深证的secid如下是 secid=0.399001，根据股票代码首位判断错了
