### PR TITLE
改用mini-racer 0.12.4 代替py_mini_racer 0.6.0 执行js代码

### DIFF
--- a/adata/common/utils/cookie.py
+++ b/adata/common/utils/cookie.py
@@ -7,12 +7,12 @@
 """
 import os
 
-from py_mini_racer import py_mini_racer
+from py_mini_racer import MiniRacer
 
 
 def ths_cookie(js_path="ths.js"):
     """获取同花顺cookie"""
-    js_code = py_mini_racer.MiniRacer()
+    js_code = MiniRacer()
     js_content = get_file_content_ths(file_path=js_path)
     js_code.eval(js_content)
     return 'v=' + js_code.call("v") + ";"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.16.0
 pandas>=0.22.0
 beautifulsoup4>=4.0.2
-py_mini_racer>=0.6.0
+mini-racer>=0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests>=2.16.0
 pandas>=0.22.0
 beautifulsoup4>=4.0.2
+py_mini_racer>=0.6.0
 mini-racer>=0.12.0


### PR DESCRIPTION
py_mini_racer 0.6.0 好多年没有维护了，太老。更改使用https://pypi.org/project/mini-racer/ 代替。
